### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,11 +4,11 @@ Priority: optional
 Maintainer: Kylin Team <team+kylin@tracker.debian.org>
 Uploaders: Aron Xu <aron@debian.org>,
            handsome_feng <jianfengli@ubuntukylin.com>
-Build-Depends: debhelper-compat (=12),
+Build-Depends: debhelper-compat (= 12),
                qtbase5-dev,
                libqt5svg5-dev,
                libqt5x11extras5-dev,
-               libglib2.0-dev (>= 2.36),
+               libglib2.0-dev,
                libgsettings-qt-dev,
                qttools5-dev-tools,
                libbamf3-dev,


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/51/743b82d21bce3e6a28bcece9b882d0865e299d.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/4b/20226eb0c49a69ae3505e4416a52dffe45428f.debug
### Control files of package ukui-menu: lines which differ (wdiff format)
* Depends: libc6 (>= 2.34), libgcc-s1 (>= 3.0), libglib2.0-0 (>= [-2.36),-] {+2.16.0),+} libgsettings-qt1 (>= 0.1+14.04.20140408), libkf5windowsystem5 (>= 5.35.0), libqt5core5a (>= 5.15.1), libqt5dbus5 (>= 5.14.1), libqt5gui5 (>= 5.14.1) | libqt5gui5-gles (>= 5.14.1), libqt5network5 (>= 5.0.2), libqt5sql5 (>= 5.0.2), libqt5svg5 (>= 5.6.0~beta), libqt5widgets5 (>= 5.15.1), libstdc++6 (>= 5.2), accountsservice, libqt5x11extras5, bamfdaemon
### Control files of package ukui-menu-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-4b20226eb0c49a69ae3505e4416a52dffe45428f-] {+51743b82d21bce3e6a28bcece9b882d0865e299d+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/c8956443-50b1-4c02-9e09-44f89a664514/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/c8956443-50b1-4c02-9e09-44f89a664514/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/ukui-menu/c8956443-50b1-4c02-9e09-44f89a664514.