### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ ukui-menu (3.0.3-2) UNRELEASED; urgency=medium
 
   * Bump debhelper from old 12 to 13.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 16 Nov 2022 04:48:37 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ ukui-menu (3.0.3-2) UNRELEASED; urgency=medium
   * Use canonical URL in Vcs-Git.
   * Update standards version to 4.6.1, no changes needed.
   * Set upstream metadata fields: Repository.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 16 Nov 2022 04:48:37 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 ukui-menu (3.0.3-2) UNRELEASED; urgency=medium
 
   * Bump debhelper from old 12 to 13.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 16 Nov 2022 04:48:37 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ ukui-menu (3.0.3-2) UNRELEASED; urgency=medium
   * Bump debhelper from old 12 to 13.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 16 Nov 2022 04:48:37 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ ukui-menu (3.0.3-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
   * Use canonical URL in Vcs-Git.
   * Update standards version to 4.6.1, no changes needed.
+  * Set upstream metadata fields: Repository.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 16 Nov 2022 04:48:37 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ukui-menu (3.0.3-2) UNRELEASED; urgency=medium
+
+  * Bump debhelper from old 12 to 13.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 16 Nov 2022 04:48:37 -0000
+
 ukui-menu (3.0.3-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends: debhelper-compat (= 13),
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/ukui/ukui-menu
-Vcs-Git: https://github.com/ukui/ukui-menu
+Vcs-Git: https://github.com/ukui/ukui-menu.git
 Vcs-Browser: https://github.com/ukui/ukui-menu
 
 Package: ukui-menu

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Kylin Team <team+kylin@tracker.debian.org>
 Uploaders: Aron Xu <aron@debian.org>,
            handsome_feng <jianfengli@ubuntukylin.com>
-Build-Depends: debhelper-compat (=12),
+Build-Depends: debhelper-compat (= 13),
                qtbase5-dev,
                libqt5svg5-dev,
                libqt5x11extras5-dev,

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper-compat (= 13),
                libkf5windowsystem-dev,
                libuchardet-dev,
                libukui-log4qt-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://github.com/ukui/ukui-menu
 Vcs-Git: https://github.com/ukui/ukui-menu.git

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper-compat (= 13),
                libkf5windowsystem-dev,
                libuchardet-dev,
                libukui-log4qt-dev
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Homepage: https://github.com/ukui/ukui-menu
 Vcs-Git: https://github.com/ukui/ukui-menu.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,5 @@
 ---
 Bug-Database: https://github.com/ukui/ukui-menu/issues
 Bug-Submit: https://github.com/ukui/ukui-menu/issues/new
+Repository: https://github.com/ukui/ukui-menu.git
 Repository-Browse: https://github.com/ukui/ukui-menu

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/ukui/ukui-menu/issues
+Bug-Submit: https://github.com/ukui/ukui-menu/issues/new
+Repository-Browse: https://github.com/ukui/ukui-menu


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Set upstream metadata fields: Repository. ([upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/2c/41d2afc452338b24187947aff268913d016902.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/4b/20226eb0c49a69ae3505e4416a52dffe45428f.debug

No differences were encountered between the control files of package \*\*ukui-menu\*\*
### Control files of package ukui-menu-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-4b20226eb0c49a69ae3505e4416a52dffe45428f-] {+2c41d2afc452338b24187947aff268913d016902+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1c6b5b75-fd4a-4d53-adc0-e3a70c541000/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1c6b5b75-fd4a-4d53-adc0-e3a70c541000/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/1c6b5b75-fd4a-4d53-adc0-e3a70c541000.